### PR TITLE
Add JDK 17 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         java:
           - 8
           - 11
+          - 17
         scala:
           - 2.13.6
           - 2.12.14
@@ -27,7 +28,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Run Tests


### PR DESCRIPTION
Also switch to Eclipse Temurin JDK, AdoptOpenJDK is discontinued.